### PR TITLE
Add support for weight modifier

### DIFF
--- a/libraries/chain/chain_config.cpp
+++ b/libraries/chain/chain_config.cpp
@@ -5,6 +5,7 @@
 
 #include <eosio/chain/chain_config.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/asset.hpp>
 
 namespace eosio { namespace chain {
 
@@ -41,6 +42,9 @@ namespace eosio { namespace chain {
 
       EOS_ASSERT( 1 <= max_authority_depth, action_validate_exception,
                   "max authority depth should be at least 1" );
+
+      EOS_ASSERT( asset(net_weight_modifier).is_valid(), action_validate_exception, "net weight modifier is invalid");
+      EOS_ASSERT( asset(cpu_weight_modifier).is_valid(), action_validate_exception, "cpu weight modifier is invalid");
 }
 
 } } // namespace eosio::chain

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -190,7 +190,7 @@ struct controller_impl {
     blog( cfg.blocks_dir ),
     fork_db( cfg.state_dir ),
     wasmif( cfg.wasm_runtime ),
-    resource_limits( db ),
+    resource_limits( s, db ),
     authorization( s, db ),
     conf( cfg ),
     chain_id( cfg.genesis.compute_chain_id() ),

--- a/libraries/chain/include/eosio/chain/chain_config.hpp
+++ b/libraries/chain/include/eosio/chain/chain_config.hpp
@@ -37,6 +37,9 @@ struct chain_config {
    uint16_t   max_inline_action_depth;             ///< recursion depth limit on sending inline actions
    uint16_t   max_authority_depth;                 ///< recursion depth limit for checking if an authority is satisfied
 
+   int64_t    net_weight_modifier;
+   int64_t    cpu_weight_modifier;
+
    void validate()const;
 
    template<typename Stream>
@@ -58,7 +61,10 @@ struct chain_config {
                  << "Max Transaction Delay: " << c.max_transaction_delay << ", "
                  << "Max Inline Action Size: " << c.max_inline_action_size << ", "
                  << "Max Inline Action Depth: " << c.max_inline_action_depth << ", "
-                 << "Max Authority Depth: " << c.max_authority_depth << "\n";
+                 << "Max Authority Depth: " << c.max_authority_depth << ", "
+
+                 << "Net Weight Modifier: " << c.net_weight_modifier << ", "
+                 << "CPU Weight Modifier: " << c.cpu_weight_modifier << "\n";
    }
 
    friend inline bool operator ==( const chain_config& lhs, const chain_config& rhs ) {
@@ -78,7 +84,9 @@ struct chain_config {
                            lhs.max_transaction_delay,
                            lhs.max_inline_action_size,
                            lhs.max_inline_action_depth,
-                           lhs.max_authority_depth
+                           lhs.max_authority_depth,
+                           lhs.net_weight_modifier,
+                           lhs.cpu_weight_modifier
                         )
                ==
                std::tie(   rhs.max_block_net_usage,
@@ -97,7 +105,9 @@ struct chain_config {
                            rhs.max_transaction_delay,
                            rhs.max_inline_action_size,
                            rhs.max_inline_action_depth,
-                           rhs.max_authority_depth
+                           rhs.max_authority_depth,
+                           rhs.net_weight_modifier,
+                           rhs.cpu_weight_modifier
                         );
    };
 
@@ -118,4 +128,5 @@ FC_REFLECT(eosio::chain::chain_config,
            (max_transaction_lifetime)(deferred_trx_expiration_window)(max_transaction_delay)
            (max_inline_action_size)(max_inline_action_depth)(max_authority_depth)
 
+           (net_weight_modifier)(cpu_weight_modifier)
 )

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -5,7 +5,11 @@
 #include <chainbase/chainbase.hpp>
 #include <set>
 
-namespace eosio { namespace chain { namespace resource_limits {
+namespace eosio { namespace chain {
+
+class controller;
+
+namespace resource_limits {
    namespace impl {
       template<typename T>
       struct ratio {
@@ -37,8 +41,8 @@ namespace eosio { namespace chain { namespace resource_limits {
 
    class resource_limits_manager {
       public:
-         explicit resource_limits_manager(chainbase::database& db)
-         :_db(db)
+         explicit resource_limits_manager(controller& c, chainbase::database& db)
+         :_control(c), _db(db)
          {
          }
 
@@ -79,6 +83,7 @@ namespace eosio { namespace chain { namespace resource_limits {
          int64_t get_account_ram_usage( const account_name& name ) const;
 
       private:
+         const controller&    _control;
          chainbase::database& _db;
    };
 } } } /// eosio::chain

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -1,3 +1,5 @@
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>
@@ -142,7 +144,8 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
          auto cpu_used_in_window                 = ((uint128_t)usage.cpu_usage.value_ex * window_size) / (uint128_t)config::rate_limiting_precision;
 
          uint128_t user_weight     = (uint128_t)cpu_weight;
-         uint128_t all_user_weight = state.total_cpu_weight;
+         uint128_t all_user_weight = state.total_cpu_weight \
+            + _control.get_global_properties().configuration.cpu_weight_modifier * _db.get_index<resource_limits_index>().indices().size();
 
          auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
 
@@ -161,7 +164,8 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
          auto net_used_in_window                 = ((uint128_t)usage.net_usage.value_ex * window_size) / (uint128_t)config::rate_limiting_precision;
 
          uint128_t user_weight     = (uint128_t)net_weight;
-         uint128_t all_user_weight = state.total_net_weight;
+         uint128_t all_user_weight = state.total_net_weight \
+            + _control.get_global_properties().configuration.net_weight_modifier * _db.get_index<resource_limits_index>().indices().size();
 
          auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;
 
@@ -281,6 +285,9 @@ void resource_limits_manager::get_account_limits( const account_name& account, i
       net_weight = buo.net_weight;
       cpu_weight = buo.cpu_weight;
    }
+
+   net_weight += _control.get_global_properties().configuration.net_weight_modifier;
+   cpu_weight += _control.get_global_properties().configuration.cpu_weight_modifier;
 }
 
 
@@ -387,7 +394,9 @@ account_resource_limit resource_limits_manager::get_account_cpu_limit_ex( const 
 
    uint128_t virtual_cpu_capacity_in_window = (uint128_t)(elastic ? state.virtual_cpu_limit : config.cpu_limit_parameters.max) * window_size;
    uint128_t user_weight     = (uint128_t)cpu_weight;
-   uint128_t all_user_weight = (uint128_t)state.total_cpu_weight;
+   uint128_t all_user_weight = (uint128_t)state.total_cpu_weight \
+      + _control.get_global_properties().configuration.cpu_weight_modifier * _db.get_index<resource_limits_index>().indices().size();
+
 
    auto max_user_use_in_window = (virtual_cpu_capacity_in_window * user_weight) / all_user_weight;
    auto cpu_used_in_window  = impl::integer_divide_ceil((uint128_t)usage.cpu_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
@@ -425,7 +434,8 @@ account_resource_limit resource_limits_manager::get_account_net_limit_ex( const 
 
    uint128_t virtual_network_capacity_in_window = (uint128_t)(elastic ? state.virtual_net_limit : config.net_limit_parameters.max) * window_size;
    uint128_t user_weight     = (uint128_t)net_weight;
-   uint128_t all_user_weight = (uint128_t)state.total_net_weight;
+   uint128_t all_user_weight = (uint128_t)state.total_net_weight \
+      + _control.get_global_properties().configuration.net_weight_modifier * _db.get_index<resource_limits_index>().indices().size();
 
 
    auto max_user_use_in_window = (virtual_network_capacity_in_window * user_weight) / all_user_weight;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -17,6 +17,8 @@ add_subdirectory(contracts)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.hpp ESCAPE_QUOTES)
 
 file(GLOB UNIT_TESTS "*.cpp")
+list(REMOVE_ITEM UNIT_TESTS
+   ${CMAKE_CURRENT_SOURCE_DIR}/resource_limits_test.cpp)
 
 add_executable( unit_test ${UNIT_TESTS} ${WASM_UNIT_TESTS} )
 target_link_libraries( unit_test eosio_chain chainbase eosio_testing fc ${PLATFORM_SPECIFIC_LIBS} )


### PR DESCRIPTION
## CPU/NET weight modifier

`[cpu/net]_weight_modifier` is considered during weight calculation instead of modifying stored states, so it can be applied globally and immediately by modifying blockchain parameters.