### PR TITLE
Fix errors on currency APIs

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1288,6 +1288,7 @@ vector<fc::variant> read_only::get_currency_balance( const read_only::get_curren
          fc::mutable_variant_object result;
          fc::variant withdraw;
          fc::variant options;
+         asset total = asset(0, cursor.get_symbol());
 
          name     issuer;
          int64_t  _deposit;
@@ -1315,6 +1316,7 @@ vector<fc::variant> read_only::get_currency_balance( const read_only::get_curren
             fc::raw::unpack(ds2, request_time);
 
             if ((quantity.get_symbol() == cursor.get_symbol()) && (issuer == p.issuer)) {
+               total += quantity;
                withdraw = fc::mutable_variant_object()
                   ("quantity", quantity)
                   ("requested_time", request_time);
@@ -1327,12 +1329,14 @@ vector<fc::variant> read_only::get_currency_balance( const read_only::get_curren
             auto balance = extended_asset(cursor, issuer);
             auto deposit = extended_asset(asset(_deposit, cursor.get_symbol()), issuer);
 
+            total += (balance.quantity + deposit.quantity);
+
             if (!p.verbose || !(*p.verbose)) {
                result = fc::mutable_variant_object()
-                  ("total", extended_asset(balance.quantity + deposit.quantity, issuer));
+                  ("total", extended_asset(total, issuer));
             } else {
                result = fc::mutable_variant_object()
-                  ("total", extended_asset(balance.quantity + deposit.quantity, issuer))
+                  ("total", extended_asset(total, issuer))
                   ("balance", balance)
                   ("deposit", deposit)
                   ("withdraw", withdraw)

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1309,17 +1309,17 @@ vector<fc::variant> read_only::get_currency_balance( const read_only::get_curren
 
             asset quantity;
             name  issuer;
-            fc::time_point_sec request_time;
+            fc::time_point_sec scheduled_time;
 
             fc::raw::unpack(ds2, quantity);
             fc::raw::unpack(ds2, issuer);
-            fc::raw::unpack(ds2, request_time);
+            fc::raw::unpack(ds2, scheduled_time);
 
             if ((quantity.get_symbol() == cursor.get_symbol()) && (issuer == p.issuer)) {
                total += quantity;
                withdraw = fc::mutable_variant_object()
-                  ("quantity", quantity)
-                  ("requested_time", request_time);
+                  ("quantity", extended_asset(quantity, issuer))
+                  ("scheduled_time", scheduled_time);
                return false;
             }
             return true;


### PR DESCRIPTION
## Changes

* Fix total currency amount to include withdrawal requested amount
* Return withdrawal requested amount in `extended_asset` format
* Print scheduled time instead of requested time for withdrawal request