### PR TITLE
Update currency RPC APIs

### DIFF
--- a/libraries/chain/asset.cpp
+++ b/libraries/chain/asset.cpp
@@ -79,22 +79,4 @@ asset asset::from_string(const string& from)
    FC_CAPTURE_LOG_AND_RETHROW( (from) )
 }
 
-string extended_asset::to_string()const {
-   return quantity.to_string() + "@" + contract.to_string();
-}
-
-extended_asset extended_asset::from_string(const string& from)
-{ try {
-   auto s = fc::trim(from);
-
-   // Find at sign in order to split asset and contract
-   auto at_pos = s.find('@');
-   EOS_ASSERT((at_pos != string::npos), asset_type_exception, "Extended asset's asset and contract should be separated with '@'");
-
-   auto asset_str = s.substr(0, at_pos);
-   auto contract_str = fc::trim(s.substr(at_pos + 1));
-
-   return extended_asset(asset::from_string(asset_str), name(contract_str));
-} FC_CAPTURE_LOG_AND_RETHROW( (from) ) }
-
 } }  // eosio::types

--- a/libraries/chain/include/eosio/chain/asset.hpp
+++ b/libraries/chain/include/eosio/chain/asset.hpp
@@ -96,13 +96,10 @@ private:
 };
 
 struct extended_asset  {
-   extended_asset(){}
-   extended_asset( asset a, name n ):quantity(a),contract(n){}
-   asset quantity;
-   name contract;
-
-   static extended_asset from_string(const string& from);
-   string                to_string()const;
+  extended_asset(){}
+  extended_asset( asset a, name n ):quantity(a),contract(n){}
+  asset quantity;
+  name contract;
 };
 
 bool  operator <  (const asset& a, const asset& b);
@@ -114,13 +111,6 @@ namespace fc {
 inline void to_variant(const eosio::chain::asset& var, fc::variant& vo) { vo = var.to_string(); }
 inline void from_variant(const fc::variant& var, eosio::chain::asset& vo) {
    vo = eosio::chain::asset::from_string(var.get_string());
-}
-}
-
-namespace fc {
-inline void to_variant(const eosio::chain::extended_asset& var, fc::variant& vo) { vo = var.to_string(); }
-inline void from_variant(const fc::variant& var, eosio::chain::extended_asset& vo) {
-   vo = eosio::chain::extended_asset::from_string(var.get_string());
 }
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1290,17 +1290,16 @@ vector<fc::variant> read_only::get_currency_balance( const read_only::get_curren
          fc::variant options;
          asset total = asset(0, cursor.get_symbol());
 
-         name     issuer;
+         uint64_t _issuer;
          int64_t  _deposit;
-         uint64_t _id;
 
-         fc::raw::unpack(ds, issuer);
+         fc::raw::unpack(ds, _issuer);
          fc::raw::unpack(ds, _deposit);
-         fc::raw::unpack(ds, _id);
 
+         name issuer = _issuer & 0xFFFFFFFFFFFFFFF0ULL;
          options = fc::mutable_variant_object()
-            ("frozen", static_cast<bool>((_id >> 56) & 0x1))
-            ("whitelist", static_cast<bool>((_id >> 56) & 0x2));
+            ("frozen", static_cast<bool>(_issuer & 0x1))
+            ("whitelist", static_cast<bool>(_issuer & 0x2));
 
          walk_key_value_table(p.code, p.account, "withdraws", [&](const key_value_object& obj2) {
             EOS_ASSERT( obj2.value.size() >= sizeof(asset) + sizeof(name) + sizeof(fc::time_point_sec), chain::asset_type_exception, "Invalid data on table");

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -321,9 +321,9 @@ public:
    fc::variant get_currency_balance( const get_currency_balance_params& params )const;
 
    struct get_currency_stats_params {
-      name           code;
-      string         symbol;
-      name           issuer;
+      name             code;
+      name             issuer;
+      optional<string> symbol;
    };
 
    struct get_currency_stats_result {
@@ -726,9 +726,9 @@ FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_params, (code)(tabl
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result_row, (code)(scope)(table)(payer)(count));
 FC_REFLECT( eosio::chain_apis::read_only::get_table_by_scope_result, (rows)(more) );
 
-FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(issuer)(symbol)(verbose));
-FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_params, (code)(symbol)(issuer));
-FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer));
+FC_REFLECT( eosio::chain_apis::read_only::get_currency_balance_params, (code)(account)(issuer)(symbol)(verbose) );
+FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_params, (code)(issuer)(symbol) );
+FC_REFLECT( eosio::chain_apis::read_only::get_currency_stats_result, (supply)(max_supply)(issuer) );
 
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_producers_result, (rows)(total_producer_vote_weight)(more) );

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -318,7 +318,7 @@ public:
       optional<bool>   verbose;
    };
 
-   vector<fc::variant> get_currency_balance( const get_currency_balance_params& params )const;
+   fc::variant get_currency_balance( const get_currency_balance_params& params )const;
 
    struct get_currency_stats_params {
       name           code;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2204,7 +2204,6 @@ int main( int argc, char** argv ) {
    // get currency balance
    string symbol;
    string issuer;
-   bool verbose_balance = false;
    auto get_currency = get->add_subcommand( "currency", localized("Retrieve information related to standard currencies"), true);
    get_currency->require_subcommand();
    auto get_balance = get_currency->add_subcommand( "balance", localized("Retrieve the balance of an account for a given currency"), false);
@@ -2212,13 +2211,13 @@ int main( int argc, char** argv ) {
    get_balance->add_option( "account", accountName, localized("The account to query balances for") )->required();
    get_balance->add_option( "issuer", issuer, localized("The name of account issuing currency") )->required();
    get_balance->add_option( "symbol", symbol, localized("The symbol for the currency if the contract operates multiple currencies") );
-   get_balance->add_flag("--verbose-balance", verbose_balance, localized("Print verbose balance"));
+   get_balance->add_flag("-v,--verbose", verbose_errors, localized("Print verbose balance"));
    get_balance->set_callback([&] {
       auto result = call(get_currency_balance_func, fc::mutable_variant_object
          ("account", accountName)
          ("code", code)
          ("issuer", issuer)
-         ("verbose", verbose_balance)
+         ("verbose", verbose_errors)
          ("symbol", symbol.empty() ? fc::variant() : symbol)
       );
 


### PR DESCRIPTION
## Changes

* Fix balance API corresponding to contract changes
According to Game-X-Coin/gxc.contracts#23, remove `_id` and parse `_issuer`.

* Rename verbose-balance option to verbose
Remove redundant boolean option of `--verbose-balacne`, share a value of `--verbose`

* Revert "Revert "Revert "Add support extended_asset initialization with '@'"""
Requested by dApp developers. `extended_asset` will be serialized by object instead of formatted string.

* Add issuer and symbol key in balance object
Requested by dApp developers. Currency balances will have issuer and symbol `keys` instead of being represented in array.

* Update RPC APIs and command-line client