### PR TITLE
Deserialize [extended_]asset as object in mongoDB

### DIFF
--- a/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_asset.hpp
+++ b/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/mongo_asset.hpp
@@ -1,0 +1,71 @@
+/**
+ *  @file
+ *  @copyright defined in gxc/LICENSE
+ */
+#pragma once
+#include <eosio/chain/asset.hpp>
+#include <fc/reflect/reflect.hpp>
+
+namespace eosio { namespace chain {
+
+template <typename T>
+inline fc::variant variant_from_stream(fc::datastream<const char*>& stream) {
+   T temp;
+   fc::raw::unpack( stream, temp );
+   return fc::variant(temp);
+}
+
+template <typename T>
+auto pack_unpack() {
+   return std::make_pair<abi_serializer::unpack_function, abi_serializer::pack_function>(
+      []( fc::datastream<const char*>& stream, bool is_array, bool is_optional) -> fc::variant  {
+         if( is_array )
+            return variant_from_stream<vector<T>>(stream);
+         else if ( is_optional )
+            return variant_from_stream<optional<T>>(stream);
+         return variant_from_stream<T>(stream);
+      },
+      []( const fc::variant& var, fc::datastream<char*>& ds, bool is_array, bool is_optional ){
+         if( is_array )
+            fc::raw::pack( ds, var.as<vector<T>>() );
+         else if ( is_optional )
+            fc::raw::pack( ds, var.as<optional<T>>() );
+         else
+            fc::raw::pack( ds,  var.as<T>());
+      }
+   );
+}
+
+
+struct mongo_asset : fc::reflect_init {
+public:
+   asset to_asset()const { return asset(amount, sym); }
+
+   friend struct fc::reflector<mongo_asset>;
+
+   void reflector_init()const {
+      auto a = to_asset(); // for validation check by eosio::asset constructor
+   }
+
+private:
+   share_type amount;
+   symbol     sym;
+};
+
+struct mongo_extended_asset : fc::reflect_init {
+public:
+   friend struct fc::reflector<mongo_extended_asset>;
+
+   void reflector_init()const {
+      extended_asset a(quantity.to_asset(), contract); // for validation check by eosio::asset constructor
+   }
+
+private:
+   mongo_asset quantity;
+   name contract;
+};
+
+}} /// namespace eosio::chain
+
+FC_REFLECT(eosio::chain::mongo_asset, (amount)(sym))
+FC_REFLECT(eosio::chain::mongo_extended_asset, (quantity)(contract))

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -32,6 +32,8 @@
 #include <mongocxx/exception/operation_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 
+#include <eosio/mongo_db_plugin/mongo_asset.hpp>
+
 namespace fc { class variant; }
 
 namespace eosio {
@@ -663,6 +665,9 @@ optional<abi_serializer> mongo_db_plugin_impl::get_abi_serializer( account_name 
                      }
                   }
                }
+               abis.add_specialized_unpack_pack("asset", eosio::chain::pack_unpack<chain::mongo_asset>());
+               abis.add_specialized_unpack_pack("extended_asset", eosio::chain::pack_unpack<chain::mongo_extended_asset>());
+
                abis.set_abi( abi, abi_serializer_max_time );
                entry.serializer.emplace( std::move( abis ) );
                abi_cache_index.insert( entry );


### PR DESCRIPTION
## Change Description
Currently, `GXC` serializes and deserializes `asset` and `extended_asset` via one string.
```
symbol: "4,GXC"
asset: "1.0000 GXC"
extended_asset: "1.0000 GXC@gxc"
```
It provides a convenient way when passing arguments, but it makes harder to index elements in mongoDB. This PR applies a specialized rule for `asset` and `extended_asset` de/serialization as object which is applied to mongo_db_plugin.

```
symbol: {decimals: 4, code: "GXC"}
asset: {amount: 10000, sym: {decimals: 4, code: "GXC"}
extended_asset: {quantity: {amount: 10000, sym: { decimals: 4, code: "GXC" }}, contract: "gxc"}
```

## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
