### PR TITLE
Optimize mongodb plugin

### DIFF
--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -4,7 +4,7 @@ if(BUILD_MONGO_DB_PLUGIN)
 
   if (libmongoc-1.0_FOUND)
 
-      find_package(libbson-1.0 1.13.0 REQUIRED)
+      find_package(libbson-1.0 REQUIRED)
       message(STATUS "Found bson headers: ${BSON_INCLUDE_DIRS}")
 
       find_package(libbsoncxx-static REQUIRED)

--- a/plugins/mongo_db_plugin/CMakeLists.txt
+++ b/plugins/mongo_db_plugin/CMakeLists.txt
@@ -4,6 +4,9 @@ if(BUILD_MONGO_DB_PLUGIN)
 
   if (libmongoc-1.0_FOUND)
 
+      find_package(libbson-1.0 1.13.0 REQUIRED)
+      message(STATUS "Found bson headers: ${BSON_INCLUDE_DIRS}")
+
       find_package(libbsoncxx-static REQUIRED)
       find_package(libmongocxx-static REQUIRED)
       find_package(libmongoc-static-1.0 REQUIRED)
@@ -21,7 +24,7 @@ if(BUILD_MONGO_DB_PLUGIN)
                ${HEADERS} )
 
   target_include_directories(mongo_db_plugin
-          PRIVATE ${LIBMONGOCXX_STATIC_INCLUDE_DIRS} ${LIBBSONCXX_STATIC_INCLUDE_DIRS}
+          PRIVATE ${LIBMONGOCXX_STATIC_INCLUDE_DIRS} ${LIBBSONCXX_STATIC_INCLUDE_DIRS} ${BSON_INCLUDE_DIRS}
           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
           )
 

--- a/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/bson.hpp
+++ b/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/bson.hpp
@@ -1,0 +1,248 @@
+/**
+ *   @file
+ *   @copyright defined in eos/LICENSE
+ */
+#pragma once
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/builder/basic/kvp.hpp>
+#include <bsoncxx/builder/stream/document.hpp>
+#include <bsoncxx/document/value.hpp>
+#include <bsoncxx/exception/exception.hpp>
+#include <bsoncxx/string/to_string.hpp>
+#include <bsoncxx/types.hpp>
+
+#include <fc/variant.hpp>
+
+namespace eosio {
+void to_bson(const fc::variant_object& o, bsoncxx::builder::core& c);
+void to_bson(const fc::variants& v, bsoncxx::builder::core& c);
+void to_bson(const fc::variant& v, bsoncxx::builder::core& c);
+bsoncxx::document::value to_bson(const fc::variant& v);
+
+void from_bson(const bsoncxx::document::view& view, fc::mutable_variant_object& o);
+void from_bson(const bsoncxx::array::view& bson_array, fc::variants& a);
+template <typename T> void from_bson(const T& ele, fc::variant& v);
+fc::variant from_bson(const bsoncxx::document::view& view);
+} // namespace eosio
+
+namespace eosio {
+
+void to_bson(const fc::variant_object& o, bsoncxx::builder::core& c)
+{
+   auto itr = o.begin();
+   while (itr != o.end()) {
+      c.key_owned(itr->key());
+      to_bson(itr->value(), c);
+      ++itr;
+   }
+}
+
+void to_bson(const fc::variants& a, bsoncxx::builder::core& c)
+{
+   auto itr = a.begin();
+   while (itr != a.end()) {
+      to_bson(*itr, c);
+      ++itr;
+   }
+}
+
+void to_bson(const fc::variant& v, bsoncxx::builder::core& c)
+{
+   switch (v.get_type()) {
+      case fc::variant::null_type: {
+         c.append(bsoncxx::types::b_null{});
+         return;
+      }
+      case fc::variant::int64_type:
+      case fc::variant::uint64_type: {
+         c.append(v.as_int64());
+         return;
+      }
+      case fc::variant::double_type:
+         c.append(v.as_double());
+         return;
+      case fc::variant::bool_type:
+         c.append(v.as_bool());
+         return;
+      case fc::variant::string_type: {
+         c.append(v.as_string());
+         return;
+      }
+      case fc::variant::blob_type: {
+         bsoncxx::types::b_binary bin;
+         bin.sub_type = bsoncxx::binary_sub_type::k_binary;
+         bin.size = v.as_blob().data.size();
+         bin.bytes = reinterpret_cast<uint8_t*>(&(*v.as_blob().data.begin()));
+         c.append(bin);
+         return;
+      }
+      case fc::variant::array_type: {
+         const fc::variants& a = v.get_array();
+         bsoncxx::builder::core sub(true);
+         to_bson(a, sub);
+         c.append(sub.extract_array());
+         return;
+      }
+      case fc::variant::object_type: {
+         const fc::variant_object& o = v.get_object();
+         if (o.size() == 1) {
+            const auto value = o.begin()->value();
+            if (o.begin()->key().compare("$oid") == 0) {
+               if (value.get_type() == fc::variant::string_type
+                  && value.as_string().size() == 12 * 2) {
+                  bsoncxx::oid oid(value.as_string());
+                  c.append(oid);
+                  break;
+               }
+            }
+            else if (o.begin()->key().compare("$date") == 0) {
+               if (value.get_type() == fc::variant::int64_type) {
+                  bsoncxx::types::b_date date(std::chrono::milliseconds(value.as_int64()));
+                  c.append(date);
+                  break;
+               }
+               else if (value.get_type() == fc::variant::object_type) {
+                  const fc::variant_object& obj = value.get_object();
+                  if (obj.size() == 1) {
+                     auto number = obj.begin();
+                     if (number->key().compare("$numberLong") == 0) {
+                        bsoncxx::types::b_date date(std::chrono::milliseconds(number->value().as_int64()));
+                        c.append(date);
+                        break;
+                     }
+                  }
+               }
+            }
+            else if (o.begin()->key().compare("$timestamp") == 0) {
+               if (value.get_type() == fc::variant::object_type) {
+                  const fc::variant_object& obj = value.get_object();
+                  if (obj.size() == 2) {
+                     auto t = obj.begin();
+                     auto i = t;
+                     ++i;
+                     if (t->key().compare("t") == 0 && i->key().compare("i") == 0) {
+                        bsoncxx::types::b_timestamp ts;
+                        ts.timestamp = static_cast<uint32_t>(t->value().as_uint64());
+                        ts.increment = static_cast<uint32_t>(i->value().as_uint64());
+                        c.append(ts);
+                        break;
+                     }
+                  }
+               }
+            }
+         }
+         bsoncxx::builder::core sub(false);
+         to_bson(o, sub);
+         c.append(sub.extract_document());
+         return;
+      }
+      default:
+         FC_THROW_EXCEPTION(
+            fc::invalid_arg_exception,
+            "Unsupported fc::variant type: " + std::to_string(v.get_type()));
+   }
+}
+
+bsoncxx::document::value to_bson(const fc::variant& v)
+{
+   bsoncxx::builder::core doc(false);
+   if (v.get_type() == fc::variant::object_type) {
+      const fc::variant_object& o = v.get_object();
+      to_bson(o, doc);
+   }
+   else if (v.get_type() != fc::variant::null_type) {
+      FC_THROW_EXCEPTION(
+         fc::invalid_arg_exception,
+         "Unsupported root fc::variant type: " + std::to_string(v.get_type()));
+   }
+   return doc.extract_document();
+}
+
+void from_bson(const bsoncxx::document::view& view, fc::mutable_variant_object& o)
+{
+   for (bsoncxx::document::element ele : view) {
+      fc::variant v;
+      from_bson(ele, v);
+      o(ele.key().data(), v);
+   }
+}
+
+void from_bson(const bsoncxx::array::view& bson_array, fc::variants& a)
+{
+   a.reserve(std::distance(bson_array.cbegin(), bson_array.cend()));
+   for (bsoncxx::array::element ele : bson_array) {
+      fc::variant v;
+      from_bson(ele, v);
+      a.push_back(v);
+   }
+}
+
+template <typename T>
+void from_bson(const T& ele, fc::variant& v)
+{
+   switch (ele.type()) {
+      case bsoncxx::type::k_double:
+         v = ele.get_double().value;
+         return;
+      case bsoncxx::type::k_utf8:
+         v = bsoncxx::string::to_string(ele.get_utf8().value);
+         return;
+      case bsoncxx::type::k_document: {
+         fc::mutable_variant_object o;
+         from_bson(ele.get_document().value, o);
+         v = o;
+         return;
+      }
+      case bsoncxx::type::k_array: {
+         bsoncxx::array::view sub_array{ele.get_array().value};
+         fc::variants a;
+         from_bson(sub_array, a);
+         v = a;
+         return;
+      }
+      case bsoncxx::type::k_binary: {
+         fc::blob blob;
+         blob.data.resize(ele.get_binary().size);
+         std::copy(ele.get_binary().bytes, ele.get_binary().bytes + ele.get_binary().size, blob.data.begin());
+         v = blob;
+         return;
+      }
+      case bsoncxx::type::k_undefined:
+      case bsoncxx::type::k_null:
+         v = fc::variant();
+         return;
+      case bsoncxx::type::k_oid:
+         v = fc::variant_object("$oid", ele.get_oid().value.to_string());
+         return;
+      case bsoncxx::type::k_bool:
+         v = ele.get_bool().value;
+         return;
+      case bsoncxx::type::k_date:
+         v = fc::variant_object("$date", ele.get_date().to_int64());
+         return;
+      case bsoncxx::type::k_int32:
+         v = ele.get_int32().value;
+         return;
+      case bsoncxx::type::k_timestamp:
+         v = fc::variant_object("$timestamp", fc::mutable_variant_object("t", ele.get_timestamp().timestamp)("i", ele.get_timestamp().increment));
+         return;
+      case bsoncxx::type::k_int64:
+         v = ele.get_int64().value;
+         return;
+      default:
+         FC_THROW_EXCEPTION(
+            fc::invalid_arg_exception,
+            "Unsupported BSON type: " + bsoncxx::to_string(ele.type()));
+   }
+}
+
+fc::variant from_bson(const bsoncxx::document::view& view)
+{
+   fc::mutable_variant_object o;
+   from_bson(view, o);
+   return o;
+}
+
+}   // namespace eosio
+

--- a/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/bson.hpp
+++ b/plugins/mongo_db_plugin/include/eosio/mongo_db_plugin/bson.hpp
@@ -14,6 +14,8 @@
 
 #include <fc/variant.hpp>
 
+#include <bson/bson.h>
+
 namespace eosio {
 void to_bson(const fc::variant_object& o, bsoncxx::builder::core& c);
 void to_bson(const fc::variants& v, bsoncxx::builder::core& c);
@@ -90,7 +92,7 @@ void to_bson(const fc::variant& v, bsoncxx::builder::core& c)
             const auto value = o.begin()->value();
             if (o.begin()->key().compare("$oid") == 0) {
                if (value.get_type() == fc::variant::string_type
-                  && value.as_string().size() == 12 * 2) {
+                  && bson_oid_is_valid(value.as_string().data(), value.as_string().size())) {
                   bsoncxx::oid oid(value.as_string());
                   c.append(oid);
                   break;

--- a/plugins/mongo_db_plugin/mongo_db_plugin.cpp
+++ b/plugins/mongo_db_plugin/mongo_db_plugin.cpp
@@ -3,6 +3,7 @@
  *  @copyright defined in eos/LICENSE
  */
 #include <eosio/mongo_db_plugin/mongo_db_plugin.hpp>
+#include <eosio/mongo_db_plugin/bson.hpp>
 #include <eosio/chain/eosio_contract.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/exceptions.hpp>
@@ -22,9 +23,6 @@
 #include <thread>
 #include <mutex>
 
-#include <bsoncxx/builder/basic/kvp.hpp>
-#include <bsoncxx/builder/basic/document.hpp>
-#include <bsoncxx/exception/exception.hpp>
 #include <bsoncxx/json.hpp>
 
 #include <mongocxx/client.hpp>
@@ -617,7 +615,7 @@ optional<abi_serializer> mongo_db_plugin_impl::get_abi_serializer( account_name 
             abi_def abi;
             if( view.find( "abi" ) != view.end()) {
                try {
-                  abi = fc::json::from_string( bsoncxx::to_json( view["abi"].get_document())).as<abi_def>();
+                  abi = from_bson( view["abi"].get_document() ).as<abi_def>();
                } catch (...) {
                   ilog( "Unable to convert account abi to abi_def for ${n}", ( "n", n ));
                   return optional<abi_serializer>();
@@ -768,42 +766,34 @@ void mongo_db_plugin_impl::_process_accepted_transaction( const chain::transacti
    trans_doc.append( kvp( "trx_id", trx_id_str ) );
 
    auto v = to_variant_with_abi( trx );
-   string trx_json = fc::json::to_string( v );
 
    try {
-      const auto& trx_value = bsoncxx::from_json( trx_json );
+      const auto& trx_value = to_bson( v );
       trans_doc.append( bsoncxx::builder::concatenate_doc{trx_value.view()} );
-   } catch( bsoncxx::exception& ) {
-      try {
-         trx_json = fc::prune_invalid_utf8( trx_json );
-         const auto& trx_value = bsoncxx::from_json( trx_json );
-         trans_doc.append( bsoncxx::builder::concatenate_doc{trx_value.view()} );
-         trans_doc.append( kvp( "non-utf8-purged", b_bool{true} ) );
-      } catch( bsoncxx::exception& e ) {
-         elog( "Unable to convert transaction JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-         elog( "  JSON: ${j}", ("j", trx_json) );
-      }
+   } catch( bsoncxx::exception& e) {
+      elog( "Unable to convert transaction to BSON: ${e}", ("e", e.what()) );
+      elog( "  JSON: ${j}", ("j", fc::json::to_string( v )) );
    }
 
-   string signing_keys_json;
+   fc::variant signing_keys;
    if( t->signing_keys_future.valid() ) {
-      signing_keys_json = fc::json::to_string( std::get<2>( t->signing_keys_future.get() ) );
+      signing_keys = std::get<2>( t->signing_keys_future.get() );
    } else {
       flat_set<public_key_type> keys;
       trx.get_signature_keys( *chain_id, fc::time_point::maximum(), keys, false );
       if( !keys.empty() ) {
-         signing_keys_json = fc::json::to_string( keys );
+         signing_keys = keys;
       }
    }
 
-   if( !signing_keys_json.empty() ) {
+   if( signing_keys.get_type() == fc::variant::array_type && signing_keys.get_array().size() > 0) {
       try {
-         const auto& keys_value = bsoncxx::from_json( signing_keys_json );
-         trans_doc.append( kvp( "signing_keys", keys_value ) );
+         bsoncxx::builder::core keys_value(true);
+         to_bson( signing_keys.get_array(), keys_value );
+         trans_doc.append( kvp( "signing_keys", keys_value.extract_array() ) );
       } catch( bsoncxx::exception& e ) {
-         // should never fail, so don't attempt to remove invalid utf8
-         elog( "Unable to convert signing keys JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-         elog( "  JSON: ${j}", ("j", signing_keys_json) );
+         elog( "Unable to convert signing keys to BSON: ${e}", ("e", e.what()) );
+         elog( "  JSON: ${j}", ("j", fc::json::to_string(signing_keys)) );
       }
    }
 
@@ -849,20 +839,11 @@ mongo_db_plugin_impl::add_action_trace( mongocxx::bulk_write& bulk_action_traces
       action_traces_doc.append( kvp( "_id", make_custom_oid() ) );
 
       auto v = to_variant_with_abi( atrace );
-      string json = fc::json::to_string( v );
       try {
-         const auto& value = bsoncxx::from_json( json );
-         action_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
-      } catch( bsoncxx::exception& ) {
-         try {
-            json = fc::prune_invalid_utf8( json );
-            const auto& value = bsoncxx::from_json( json );
-            action_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
-            action_traces_doc.append( kvp( "non-utf8-purged", b_bool{true} ) );
-         } catch( bsoncxx::exception& e ) {
-            elog( "Unable to convert action trace JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-            elog( "  JSON: ${j}", ("j", json) );
-         }
+         action_traces_doc.append( bsoncxx::builder::concatenate_doc{to_bson( v )} );
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert action trace to BSON: ${e}", ("e", e.what()) );
+         elog( "  JSON: ${j}", ("j", fc::json::to_string( v )) );
       }
       if( t->receipt.valid() ) {
          action_traces_doc.append( kvp( "trx_status", std::string( t->receipt->status ) ) );
@@ -909,20 +890,11 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
    if( store_transaction_traces && write_ttrace ) {
       try {
          auto v = to_variant_with_abi( *t );
-         string json = fc::json::to_string( v );
          try {
-            const auto& value = bsoncxx::from_json( json );
-            trans_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
-         } catch( bsoncxx::exception& ) {
-            try {
-               json = fc::prune_invalid_utf8( json );
-               const auto& value = bsoncxx::from_json( json );
-               trans_traces_doc.append( bsoncxx::builder::concatenate_doc{value.view()} );
-               trans_traces_doc.append( kvp( "non-utf8-purged", b_bool{true} ) );
-            } catch( bsoncxx::exception& e ) {
-               elog( "Unable to convert transaction JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-               elog( "  JSON: ${j}", ("j", json) );
-            }
+            trans_traces_doc.append( bsoncxx::builder::concatenate_doc{to_bson( v )} );
+         } catch( bsoncxx::exception& e ) {
+            elog( "Unable to convert transaction to BSON: ${e}", ("e", e.what()) );
+            elog( "  JSON: ${j}", ("j", fc::json::to_string( v )) );
          }
          trans_traces_doc.append( kvp( "createdAt", b_date{now} ) );
 
@@ -931,7 +903,7 @@ void mongo_db_plugin_impl::_process_applied_transaction( const chain::transactio
                EOS_ASSERT( false, chain::mongo_db_insert_fail, "Failed to insert trans ${id}", ("id", t->id) );
             }
          } catch( ... ) {
-            handle_mongo_exception( "trans_traces insert: " + json, __LINE__ );
+            handle_mongo_exception( "trans_traces insert: " + fc::json::to_string( v ), __LINE__ );
          }
       } catch( ... ) {
          handle_mongo_exception( "trans_traces serialization: " + t->id.str(), __LINE__ );
@@ -978,20 +950,11 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
 
       const chain::block_header_state& bhs = *bs;
 
-      auto json = fc::json::to_string( bhs );
       try {
-         const auto& value = bsoncxx::from_json( json );
-         block_state_doc.append( kvp( "block_header_state", value ) );
-      } catch( bsoncxx::exception& ) {
-         try {
-            json = fc::prune_invalid_utf8( json );
-            const auto& value = bsoncxx::from_json( json );
-            block_state_doc.append( kvp( "block_header_state", value ) );
-            block_state_doc.append( kvp( "non-utf8-purged", b_bool{true} ) );
-         } catch( bsoncxx::exception& e ) {
-            elog( "Unable to convert block_header_state JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-            elog( "  JSON: ${j}", ("j", json) );
-         }
+         block_state_doc.append( kvp( "block_header_state", to_bson( fc::variant(bhs) ) ) );
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert block_header_state to BSON: ${e}", ("e", e.what()) );
+         elog( "  JSON: ${j}", ("j", fc::json::to_string( bhs )) );
       }
       block_state_doc.append( kvp( "createdAt", b_date{now} ) );
 
@@ -1008,7 +971,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
             }
          }
       } catch( ... ) {
-         handle_mongo_exception( "block_states insert: " + json, __LINE__ );
+         handle_mongo_exception( "block_states insert: " + fc::json::to_string( bhs ), __LINE__ );
       }
    }
 
@@ -1018,20 +981,11 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
                         kvp( "block_id", block_id_str ) );
 
       auto v = to_variant_with_abi( *bs->block );
-      auto json = fc::json::to_string( v );
       try {
-         const auto& value = bsoncxx::from_json( json );
-         block_doc.append( kvp( "block", value ) );
-      } catch( bsoncxx::exception& ) {
-         try {
-            json = fc::prune_invalid_utf8( json );
-            const auto& value = bsoncxx::from_json( json );
-            block_doc.append( kvp( "block", value ) );
-            block_doc.append( kvp( "non-utf8-purged", b_bool{true} ) );
-         } catch( bsoncxx::exception& e ) {
-            elog( "Unable to convert block JSON to MongoDB JSON: ${e}", ("e", e.what()) );
-            elog( "  JSON: ${j}", ("j", json) );
-         }
+         block_doc.append( kvp( "block", to_bson( v ) ) );
+      } catch( bsoncxx::exception& e ) {
+         elog( "Unable to convert block to BSON: ${e}", ("e", e.what()) );
+         elog( "  JSON: ${j}", ("j", fc::json::to_string( v )) );
       }
       block_doc.append( kvp( "createdAt", b_date{now} ) );
 
@@ -1048,7 +1002,7 @@ void mongo_db_plugin_impl::_process_accepted_block( const chain::block_state_ptr
             }
          }
       } catch( ... ) {
-         handle_mongo_exception( "blocks insert: " + json, __LINE__ );
+         handle_mongo_exception( "blocks insert: " + fc::json::to_string( v ), __LINE__ );
       }
    }
 }
@@ -1326,11 +1280,11 @@ void mongo_db_plugin_impl::update_account(const chain::action& act)
          }
          if( account ) {
             abi_def abi_def = fc::raw::unpack<chain::abi_def>( setabi.abi );
-            const string json_str = fc::json::to_string( abi_def );
+            auto v = fc::variant( abi_def );
 
-            try{
+            try {
                auto update_from = make_document(
-                     kvp( "$set", make_document( kvp( "abi", bsoncxx::from_json( json_str )),
+                     kvp( "$set", make_document( kvp( "abi", to_bson( v )),
                                                  kvp( "updatedAt", b_date{now} ))));
 
                try {
@@ -1342,8 +1296,8 @@ void mongo_db_plugin_impl::update_account(const chain::action& act)
                   handle_mongo_exception( "account update", __LINE__ );
                }
             } catch( bsoncxx::exception& e ) {
-               elog( "Unable to convert abi JSON to MongoDB JSON: ${e}", ("e", e.what()));
-               elog( "  JSON: ${j}", ("j", json_str));
+               elog( "Unable to convert abi JSON to BSON: ${e}", ("e", e.what()));
+               elog( "  JSON: ${j}", ("j", fc::json::to_string( v )));
             }
          }
       }
@@ -1444,7 +1398,7 @@ void mongo_db_plugin_impl::init() {
       auto& mongo_conn = *client;
 
       auto accounts = mongo_conn[db_name][accounts_col];
-      if( accounts.count( make_document()) == 0 ) {
+      if( accounts.estimated_document_count() == 0 ) {
          auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
                std::chrono::microseconds{fc::time_point::now().time_since_epoch().count()} );
 
@@ -1730,3 +1684,4 @@ void mongo_db_plugin::plugin_shutdown()
 }
 
 } // namespace eosio
+

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -170,6 +170,7 @@ class Node(object):
         tmpStr=re.sub(r'ObjectId\("(\w+)"\)', r'"ObjectId-\1"', tmpStr)
         tmpStr=re.sub(r'ISODate\("([\w|\-|\:|\.]+)"\)', r'"ISODate-\1"', tmpStr)
         tmpStr=re.sub(r'NumberLong\("(\w+)"\)', r'"NumberLong-\1"', tmpStr)
+        tmpStr=re.sub(r'NumberLong\((\w+)\)', r'\1', tmpStr)
         return tmpStr
 
     @staticmethod


### PR DESCRIPTION
Written by @UMU618

GameXCoin utilizes mongoDB heavily in services, so cherry-picked this before being merged into EOSIO mainline release. Next paragraph contains the description of original pull request.

---
mongodb plugin performance greatly enhanced

before:
fc::variant -> JSON string -> bson

now:
fc::variant -> bson

the conversion performance is 40~50x than before, when processes big blocks.

Just add bson.hpp, hope it will pass all checks and tests.